### PR TITLE
fix missing variable for country-only import

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -56,6 +56,7 @@ if [ -n "${planetUrl}" ]; then
 
 else
     # Options for a Geofabrik Extract
+    osmdatafilename=${osmdatacountry}-latest.osm.pbf
     osmdataurl=${geofabrikUrl}${osmdatafolder}${osmdatafilename}
     osmupdates=${geofabrikUrl}${osmdatafolder}${osmdatacountry}-updates
 fi


### PR DESCRIPTION
The run.sh script doesn't define $osmdatafilename when not importing the whole planet - causing the download from GeoFabrik and the import to fail.

The following fix defines the variable (from $osmdatacountry, which is defined in  .config.sh); this fixes the download and allows the script to run normally.
