### PR TITLE
git protocol change

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -165,7 +165,7 @@ eval cd /home/${username}
 if [ ! -d "/home/${username}/Nominatim/.git" ]; then
     # Install
     echo "\n#\tInstalling Nominatim software" >> ${setupLogFile}
-    sudo -u ${username} git clone --recursive git://github.com/twain47/Nominatim.git >> ${setupLogFile}
+    sudo -u ${username} git clone --recursive https://github.com/twain47/Nominatim.git >> ${setupLogFile}
     cd Nominatim
 else
     # Update


### PR DESCRIPTION
The install script does not clone the nominatim repo properly when behind some firewalls. Read more here:

http://git-scm.com/book/en/Git-on-the-Server-The-Protocols

Relevant section:

"{git://} also requires firewall access to port 9418, which isn’t a standard port that corporate firewalls always allow. Behind big corporate firewalls, this obscure port is commonly blocked."
